### PR TITLE
feat: add editorialgroup model with TechnicalCommittee support

### DIFF
--- a/grammars/relaton-cc.rng
+++ b/grammars/relaton-cc.rng
@@ -14,5 +14,42 @@
         <value>advisory</value>
       </choice>
     </define>
+    <define name="BibDataExtensionType">
+      <optional>
+        <attribute name="schema-version"/>
+      </optional>
+      <optional>
+        <ref name="doctype"/>
+      </optional>
+      <optional>
+        <ref name="docsubtype"/>
+      </optional>
+      <optional>
+        <ref name="editorialgroup"/>
+      </optional>
+      <ref name="flavor"/>
+      <zeroOrMore>
+        <ref name="ics"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="structuredidentifier"/>
+      </zeroOrMore>
+      <ref name="DocumentImages"/>
+    </define>
   </include>
+  <define name="editorialgroup">
+    <element name="editorialgroup">
+      <oneOrMore>
+        <ref name="technical-committee"/>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="technical-committee">
+    <element name="committee">
+      <optional>
+        <attribute name="type"/>
+      </optional>
+      <text/>
+    </element>
+  </define>
 </grammar>

--- a/lib/relaton/calconnect/model/editorial_group.rb
+++ b/lib/relaton/calconnect/model/editorial_group.rb
@@ -1,0 +1,19 @@
+require "lutaml/model"
+require_relative "technical_committee"
+
+module Relaton
+  module Calconnect
+    class EditorialGroup < Lutaml::Model::Serializable
+      attribute :committee, TechnicalCommittee, collection: true
+
+      xml do
+        root "editorialgroup"
+        map_element "committee", to: :committee
+      end
+
+      key_value do
+        map "committee", to: :committee
+      end
+    end
+  end
+end

--- a/lib/relaton/calconnect/model/ext.rb
+++ b/lib/relaton/calconnect/model/ext.rb
@@ -1,9 +1,32 @@
 require_relative "doctype"
+require_relative "editorial_group"
 
 module Relaton
   module Calconnect
     class Ext < Bib::Ext
       attribute :doctype, Doctype
+      attribute :editorialgroup, EditorialGroup
+
+      xml do
+        root "ext"
+        map_attribute "schema-version", to: :schema_version, render_default: true
+        map_element "doctype", to: :doctype
+        map_element "subdoctype", to: :subdoctype
+        map_element "flavor", to: :flavor
+        map_element "ics", to: :ics
+        map_element "structuredidentifier", to: :structuredidentifier
+        map_element "editorialgroup", to: :editorialgroup
+      end
+
+      key_value do
+        map "schema_version", to: :schema_version, render_default: true
+        map "doctype", to: :doctype
+        map "subdoctype", to: :subdoctype
+        map "flavor", to: :flavor
+        map "ics", to: :ics
+        map "structuredidentifier", to: :structuredidentifier
+        map "editorialgroup", to: :editorialgroup
+      end
 
       def get_schema_version = Relaton.schema_versions["relaton-model-cc"]
     end

--- a/lib/relaton/calconnect/model/technical_committee.rb
+++ b/lib/relaton/calconnect/model/technical_committee.rb
@@ -1,0 +1,21 @@
+require "lutaml/model"
+
+module Relaton
+  module Calconnect
+    class TechnicalCommittee < Lutaml::Model::Serializable
+      attribute :type, :string
+      attribute :content, :string
+
+      xml do
+        root "committee"
+        map_attribute "type", to: :type
+        map_content to: :content
+      end
+
+      key_value do
+        map "type", to: :type
+        map "content", to: :content
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds `editorialgroup` support to the CalConnect Ext model, enabling full round-trip parsing and serialization of technical committee data.

## Changes

- **New**: `EditorialGroup` lutaml-model class with `committee` collection
- **New**: `TechnicalCommittee` lutaml-model class with `type` attribute and `content`
- **Modified**: `Ext` model now includes `editorialgroup` attribute with full `xml do` and `key_value do` mappings
- **Modified**: RNG grammar `BibDataExtensionType` override now includes all parent elements (`flavor`, `structuredidentifier`, `DocumentImages`) plus new `editorialgroup`

## Verification

- All 34 specs pass (`bundle exec rspec`)
- Editorialgroup round-trips correctly: `{"editorialgroup":{"committee":[{"type":"TC","content":"TCC"}]}}`
- RNG validation passes for all fixtures